### PR TITLE
"use strict" should not be applied globally

### DIFF
--- a/DetectRTC.js
+++ b/DetectRTC.js
@@ -26,9 +26,9 @@
 // DetectRTC.videoResolutions
 // DetectRTC.screenResolutions
 
-'use strict';
-
 (function() {
+    'use strict';
+    
     // detect node-webkit
     var browser = getBrowserInfo();
 


### PR DESCRIPTION
We use `DetectRTC` in our project and minify it with all our production code. The problem now is that DetectRTC declares `'use strict'` outside of it's function code so the strict mode is applied to our production code which causes some troubles. Therefore `'use strict'` should be declared inside the function scope of DetectRTC to not break projects having it as a dependency.
